### PR TITLE
Fix MATLAB dependency path issue for Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,16 @@ RUN mkdir -p /tmp/matlab && \
     echo "Manifest-Version: 1.0" > /tmp/matlab/manifest.txt && \
     jar cfm /tmp/matlab/engine.jar /tmp/matlab/manifest.txt
 
+RUN sed -i 's|<matlab.engine.jar>.*</matlab.engine.jar>|<matlab.engine.jar>/tmp/matlab/engine.jar</matlab.engine.jar>|' \
+    modules/cloudsim-simulation-backend/pom.xml
+
 # Build with sufficient memory for Maven
 ENV MAVEN_OPTS="-Xmx1024m -Xms512m"
 
-# Build all modules in correct order with the dummy MATLAB jar
+# Build all modules in correct order
 RUN mvn clean install -DskipTests -pl modules/cloudsim -am && \
     mvn clean install -DskipTests -pl modules/cloudsim-examples -am && \
-    mvn clean install -DskipTests -pl modules/cloudsim-simulation-backend -am \
-    -Dmatlab.engine.jar=/tmp/matlab/engine.jar
+    mvn clean install -DskipTests -pl modules/cloudsim-simulation-backend -am
 
 # Runtime stage
 FROM eclipse-temurin:21-jre-alpine


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix MATLAB dependency path in Docker build process

- Replace Maven command-line parameter with direct POM modification

- Streamline build process by removing redundant parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Maven Build"] --> B["POM Modification"]
  B --> C["MATLAB Engine JAR Path"]
  C --> D["Successful Deployment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Fix MATLAB dependency path configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Add <code>sed</code> command to modify POM file directly with MATLAB jar path<br> <li> Remove Maven command-line parameter for <code>matlab.engine.jar</code><br> <li> Simplify build command by removing redundant parameter passing</ul>


</details>


  </td>
  <td><a href="https://github.com/kierre-yes/research_sim/pull/20/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

