### PR TITLE
interpretation: add more journal-enhanced statements on analysis

### DIFF
--- a/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/AnalysisInterpretationService.java
+++ b/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/AnalysisInterpretationService.java
@@ -66,7 +66,8 @@ public class AnalysisInterpretationService {
         SimulationResults.Summary summary = results.getSummary();
         
         double performanceScore = calculatePerformanceScore(summary);
-        String grade = getPerformanceGrade(performanceScore);
+        String workloadType = inferWorkloadType(summary);
+        String grade = getPerformanceGradeWithContext(performanceScore, workloadType);
         
         analysis.put("grade", grade);
         analysis.put("summary", String.format(
@@ -105,12 +106,18 @@ public class AnalysisInterpretationService {
             (int) results.getSchedulingLog().stream().filter(entry -> "assignment".equals(entry.getType())).count() : 1;
         double energyPerTask = taskCount > 0 ? summary.getEnergyConsumption() / taskCount : summary.getEnergyConsumption();
         
+        String sustainabilityCategory = categorizeEnergyEfficiencyWithSustainability(
+            summary.getEnergyConsumption(), summary.getMakespan(), "standard"
+        );
+        
         interpretations.put("energyConsumption", String.format(
             "Total energy consumption of %.2f Wh reflects %s energy efficiency. " +
-            "This translates to approximately %.4f Wh per task (%d tasks completed).",
+            "This translates to approximately %.4f Wh per task (%d tasks completed). " +
+            "Carbon impact assessment: %s.",
             summary.getEnergyConsumption(),
-            categorizeEnergyEfficiency(summary.getEnergyConsumption(), summary.getMakespan()),
-            energyPerTask, taskCount
+            sustainabilityCategory,
+            energyPerTask, taskCount,
+            getCarbonImpactDescription(summary.getEnergyConsumption())
         ));
         
         interpretations.put("responseTime", String.format(
@@ -258,7 +265,9 @@ public class AnalysisInterpretationService {
             }
         }
         
-        StringBuilder explanation = new StringBuilder("Effect sizes indicate practical significance: ");
+        StringBuilder explanation = new StringBuilder(
+            "Effect sizes indicate practical significance using cloud computing-specific thresholds: "
+        );
         
         if (effectCounts.get("Large") > 0) {
             explanation.append(String.format("%d large effects (substantial practical difference), ", effectCounts.get("Large")));
@@ -302,6 +311,67 @@ public class AnalysisInterpretationService {
         if (energyPerSecond < 0.3) return "good";
         if (energyPerSecond < 0.5) return "moderate";
         return "poor";
+    }
+    
+
+    private String categorizeEnergyEfficiencyWithSustainability(double energy, double makespan, String datacenterLocation) {
+        double energyPerSecond = energy / makespan;
+        
+        double sustainabilityFactor = getSustainabilityFactor(datacenterLocation);
+        double adjustedEnergyRate = energyPerSecond * sustainabilityFactor;
+        
+        if (adjustedEnergyRate < 0.05) {
+            return "excellent (carbon-neutral)";
+        } else if (adjustedEnergyRate < 0.15) {
+            return "good (low-carbon)";
+        } else if (adjustedEnergyRate < 0.35) {
+            return "moderate (standard emissions)";
+        } else {
+            return "poor (high-carbon footprint)";
+        }
+    }
+    
+
+    private double getSustainabilityFactor(String datacenterLocation) {
+        if (datacenterLocation == null) {
+            return 1.0; 
+        }
+        
+        switch (datacenterLocation.toLowerCase()) {
+            case "renewable":
+            case "green":
+            case "nordic": // Nordic countries have high renewable energy
+                return 0.3; // 70% reduction due to renewable energy
+            case "hybrid":
+            case "europe":
+                return 0.6; // 40% reduction due to partial renewable
+            case "standard":
+            case "usa":
+                return 0.8; // 20% reduction due to some green initiatives
+            case "coal":
+            case "fossil":
+                return 1.5; // 50% penalty for fossil fuel dependency
+            default:
+                return 1.0; // Baseline carbon footprint
+        }
+    }
+    
+    private String getCarbonImpactDescription(double energyWh) {
+        // Convert Wh to kWh
+        double energyKwh = energyWh / 1000.0;
+        
+        // Average global CO2 emissions: ~0.475 kg CO2 per kWh IEA 2024 data
+        double co2Kg = energyKwh * 0.475;
+        
+        if (co2Kg < 0.01) {
+            return "negligible CO2 emissions";
+        } else if (co2Kg < 0.1) {
+            return String.format("~%.3f kg CO2 equivalent (low impact)", co2Kg);
+        } else if (co2Kg < 1.0) {
+            return String.format("~%.2f kg CO2 equivalent (moderate impact)", co2Kg);
+        } else {
+            return String.format("~%.1f kg CO2 equivalent (consider optimization for sustainability)", co2Kg);
+        }
     }
     
     private String categorizeResponseTime(double responseTime) {
@@ -413,6 +483,26 @@ public class AnalysisInterpretationService {
         return "F";                       // Below 20%
     }
     
+    
+    private String getPerformanceGradeWithContext(double score, String workloadType) {
+        double adjustedScore = score;
+        
+        if ("compute-intensive".equalsIgnoreCase(workloadType)) {
+            
+            adjustedScore = score * 1.05; 
+        } else if ("data-intensive".equalsIgnoreCase(workloadType)) {
+            adjustedScore = score;
+        } else if ("mixed".equalsIgnoreCase(workloadType) || workloadType == null) {
+            adjustedScore = score;
+        } else if ("real-time".equalsIgnoreCase(workloadType)) {
+            adjustedScore = score * 0.95; 
+        }
+        
+        adjustedScore = Math.min(1.0, adjustedScore);
+        
+        return getPerformanceGrade(adjustedScore);
+    }
+    
     private String identifyStrengths(SimulationResults.Summary summary) {
         List<String> strengths = new ArrayList<>();
         
@@ -469,6 +559,23 @@ public class AnalysisInterpretationService {
             case "loadBalance": return "degree of imbalance";
             case "loadImbalance": return "degree of imbalance";
             default: return metricName;
+        }
+    }
+    private String inferWorkloadType(SimulationResults.Summary summary) {
+        double utilizationPerMakespan = summary.getResourceUtilization() / summary.getMakespan();
+        double energyPerMakespan = summary.getEnergyConsumption() / summary.getMakespan();
+        
+        if (summary.getResourceUtilization() > 75 && summary.getMakespan() > 20) {
+            return "compute-intensive";
+        }
+        else if (summary.getMakespan() < 10 && summary.getResourceUtilization() < 70) {
+            return "data-intensive";
+        }
+        else if (summary.getResponseTime() < 2) {
+            return "real-time";
+        }
+        else {
+            return "mixed";
         }
     }
 }

--- a/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/ComparisonService.java
+++ b/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/ComparisonService.java
@@ -353,17 +353,10 @@ public class ComparisonService {
             test.setImprovementPercentage(0.0);
         }
         
-        // Effect size interpretation
+        //cloud computing metrics need adjusted thresholds
         double absCohensD = Math.abs(cohensD);
-        if (absCohensD < 0.2) {
-            test.setEffectSize("Negligible");
-        } else if (absCohensD < 0.5) {
-            test.setEffectSize("Small");
-        } else if (absCohensD < 0.8) {
-            test.setEffectSize("Medium");
-        } else {
-            test.setEffectSize("Large");
-        }
+        String effectSize = getCloudComputingEffectSize(absCohensD, metricName);
+        test.setEffectSize(effectSize);
         
         return test;
     }
@@ -418,6 +411,44 @@ public class ComparisonService {
             default:
                 logger.warn("Unknown metric type: {}, assuming lower is better", metricName);
                 return true;
+        }
+    }
+    
+    
+    private String getCloudComputingEffectSize(double cohensD, String metricName) {
+        
+        switch (metricName) {
+            case "makespan":
+            case "responseTime":
+                if (cohensD < 0.15) return "Negligible";
+                else if (cohensD < 0.4) return "Small";
+                else if (cohensD < 0.75) return "Medium";
+                else return "Large";
+                
+            case "energyConsumption":
+                if (cohensD < 0.25) return "Negligible";
+                else if (cohensD < 0.6) return "Small";
+                else if (cohensD < 1.0) return "Medium";
+                else return "Large";
+                
+            case "resourceUtilization":
+                if (cohensD < 0.2) return "Negligible";
+                else if (cohensD < 0.5) return "Small";
+                else if (cohensD < 0.8) return "Medium";
+                else return "Large";
+                
+            case "loadBalance":
+            case "loadImbalance":
+                if (cohensD < 0.1) return "Negligible";
+                else if (cohensD < 0.35) return "Small";
+                else if (cohensD < 0.7) return "Medium";
+                else return "Large";
+                
+            default:
+                if (cohensD < 0.2) return "Negligible";
+                else if (cohensD < 0.5) return "Small";
+                else if (cohensD < 0.8) return "Medium";
+                else return "Large";
         }
     }
     


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced analysis with sustainability and carbon impact metrics

- Added workload type inference for contextual performance grading

- Implemented cloud computing-specific effect size thresholds

- Improved energy efficiency categorization with datacenter location factors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Analysis Service"] --> B["Workload Type Inference"]
  A --> C["Sustainability Metrics"]
  A --> D["Carbon Impact Assessment"]
  B --> E["Context-aware Performance Grading"]
  C --> F["Energy Efficiency with Location"]
  D --> G["CO2 Emissions Calculation"]
  H["Comparison Service"] --> I["Cloud-specific Effect Sizes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AnalysisInterpretationService.java</strong><dd><code>Enhanced analysis with sustainability and workload context</code></dd></summary>
<hr>

modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/AnalysisInterpretationService.java

<ul><li>Added workload type inference based on resource utilization and <br>makespan<br> <li> Implemented sustainability-aware energy efficiency categorization with <br>datacenter location factors<br> <li> Added carbon impact assessment with CO2 emissions calculation<br> <li> Enhanced performance grading with workload type context<br> <li> Updated energy consumption interpretation to include carbon footprint</ul>


</details>


  </td>
  <td><a href="https://github.com/kierre-yes/research_sim/pull/45/files#diff-7b39e0b3c70c004c1b132f52fcc739bcf60747c51d4c175b84174b6daf241b1a">+112/-5</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ComparisonService.java</strong><dd><code>Cloud-specific statistical effect size thresholds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/ComparisonService.java

<ul><li>Replaced generic Cohen's d thresholds with cloud computing-specific <br>effect sizes<br> <li> Added metric-specific effect size calculations for makespan, energy, <br>utilization, and load balance<br> <li> Updated effect size interpretation to be more relevant for cloud <br>computing metrics</ul>


</details>


  </td>
  <td><a href="https://github.com/kierre-yes/research_sim/pull/45/files#diff-33dcf4045babf420c5f1ab7b6438ed7dc6bd1d4ed3e97ba5f80f175d1bd32329">+41/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

