### PR TITLE
add reset() on the progress holder

### DIFF
--- a/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/controller/ApiController.java
+++ b/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/controller/ApiController.java
@@ -632,6 +632,9 @@ long maxBytes = 1024L * 1024 * 1024; // 1 GB
             iterationService.requestCancellation();
             comparisonService.requestCancellation();
             
+            // Reset progress on cancellation
+            SimulationProgressHolder.reset();
+            
             Map<String, Object> response = new HashMap<>();
             response.put("message", "Simulation cancellation requested");
             response.put("status", "cancelled");

--- a/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/ComparisonService.java
+++ b/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/ComparisonService.java
@@ -74,6 +74,7 @@ public class ComparisonService {
         for (int i = 1; i <= totalComparisons; i++) {
             if (isCancelled) {
                 logger.info("Comparison cancelled at iteration {}", i);
+                SimulationProgressHolder.reset(); // Reset progress on cancellation
                 throw new RuntimeException("Comparison cancelled by user");
             }
             SimulationProgressHolder.setCurrentIteration(i, totalComparisons, "Running");
@@ -85,6 +86,7 @@ public class ComparisonService {
             eacoResultsList.addAll(eacoSingleResult.getIndividualResults());
             
             if (isCancelled) {
+                SimulationProgressHolder.reset(); // Reset progress on cancellation
                 throw new RuntimeException("Comparison cancelled by user");
             }
             
@@ -141,6 +143,14 @@ public class ComparisonService {
         comparison.setDatasetId(computeDatasetId(request.getWorkloadPath()));
         
         SimulationProgressHolder.setStage("Comparison Completed");
+        java.util.concurrent.CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(2000); 
+                SimulationProgressHolder.reset();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
         
         logger.info("Comparison completed in {} ms", comparison.getTotalExecutionTime());
         

--- a/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/IterationService.java
+++ b/modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/IterationService.java
@@ -92,6 +92,7 @@ public class IterationService {
                 for (CompletableFuture<SimulationResults> future : futures) {
                     future.cancel(true);
                 }
+                SimulationProgressHolder.reset(); // Reset progress on cancellation
                 throw new RuntimeException("Iterations cancelled by user");
             }
             
@@ -107,6 +108,7 @@ public class IterationService {
         } catch (Exception e) {
             if (isCancelled) {
                 logger.info("Iterations cancelled during execution");
+                SimulationProgressHolder.reset(); // Reset progress on cancellation
                 throw new RuntimeException("Iterations cancelled by user");
             }
             logger.error("Error waiting for iterations to complete", e);
@@ -136,6 +138,14 @@ public class IterationService {
         iterationResults.setDatasetId(computeDatasetId(request.getWorkloadPath()));
         
         SimulationProgressHolder.setStage(algorithmName + " - Completed");
+        java.util.concurrent.CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(2000); 
+                SimulationProgressHolder.reset();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
         
         return iterationResults;
     }
@@ -240,6 +250,14 @@ public class IterationService {
         iterationResults.setDatasetId(computeDatasetId(request.getWorkloadPath()));
         
         SimulationProgressHolder.setStage(algorithmName + " - Completed");
+        java.util.concurrent.CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(2000); 
+                SimulationProgressHolder.reset();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
         
         return iterationResults;
     }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add progress reset functionality to simulation lifecycle

- Reset progress on simulation cancellation events

- Auto-reset progress after completion with delay


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Simulation Start"] --> B["Progress Tracking"]
  B --> C["Cancellation Event"]
  B --> D["Completion Event"]
  C --> E["Immediate Reset"]
  D --> F["Delayed Reset (2s)"]
  E --> G["Progress Cleared"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ApiController.java</strong><dd><code>Reset progress on simulation cancellation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/controller/ApiController.java

<ul><li>Add <code>SimulationProgressHolder.reset()</code> call in cancellation endpoint</ul>


</details>


  </td>
  <td><a href="https://github.com/kierre-yes/research_sim/pull/47/files#diff-799e3ee0737fe7d91f2fe0161a1bfccf9f957010850d3ca5c8281798d04ceab4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ComparisonService.java</strong><dd><code>Progress reset on cancellation and completion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/ComparisonService.java

<ul><li>Add progress reset calls on cancellation events<br> <li> Add async progress reset after completion with 2-second delay</ul>


</details>


  </td>
  <td><a href="https://github.com/kierre-yes/research_sim/pull/47/files#diff-33dcf4045babf420c5f1ab7b6438ed7dc6bd1d4ed3e97ba5f80f175d1bd32329">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IterationService.java</strong><dd><code>Progress reset on cancellation and completion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/cloudsim-simulation-backend/src/main/java/com/thesis/cloudsim/service/IterationService.java

<ul><li>Add progress reset calls on cancellation events<br> <li> Add async progress reset after completion with 2-second delay<br> <li> Apply to both <code>runIterations</code> and <code>runIterationsWithOffset</code> methods</ul>


</details>


  </td>
  <td><a href="https://github.com/kierre-yes/research_sim/pull/47/files#diff-e2c1d01be3b9d925042b2d8b46ed7e74bbbf29c5c238a4da8eda357aeddb9663">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

